### PR TITLE
Allow root level and .global additional properties in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow root level additional properties in schema.
+
 ## [0.1.0] - 2024-05-24
 
 - First release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow root level additional properties in schema.
+- Allow additional properties under `.global` in schema.
 
 ## [0.1.0] - 2024-05-24
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -9,6 +9,7 @@ HELM_UNITTEST := ./bin/helm-unittest-$(HELM_UNITTEST_VERSION)
 .PHONY: gen-schma
 gen-schema: $(HELM_SCHEMA) ## Generates schema.
 	$(HELM_SCHEMA) -l debug
+	sed -i 's/^  "additionalProperties": false,$$/  "additionalProperties": true,/g' ./helm/ingress-sla/values.schema.json
 
 .PHONY: unit-test
 unit-test: $(HELM_UNITTEST) ## Run Helm chart unit tests.

--- a/helm/ingress-sla/values.schema.json
+++ b/helm/ingress-sla/values.schema.json
@@ -8,7 +8,7 @@
       "type": "string"
     },
     "global": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "checkDefaults": {
           "additionalProperties": false,

--- a/helm/ingress-sla/values.schema.json
+++ b/helm/ingress-sla/values.schema.json
@@ -1,5 +1,5 @@
 {
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "baseDomain": {
       "default": "",

--- a/helm/ingress-sla/values.yaml
+++ b/helm/ingress-sla/values.yaml
@@ -1,6 +1,11 @@
 # -- Defaults to the value configured in the "giantswarm" App Catalog.
 baseDomain: ""
 
+# @schema
+# type: object
+# additionalProperties: true
+# required: true
+# @schema
 global:
   # -- SLA checks' defaults.
   checkDefaults:


### PR DESCRIPTION
Otherwise when linking `*-cluster-values`:

      values don't meet the specifications of the schema(s) in the following chart(s):
      ingress-sla:
      - (root): Additional property clusterCIDR is not allowed
      - (root): Additional property clusterDNSIP is not allowed
      - (root): Additional property clusterID is not allowed
      - (root): Additional property provider is not allowed
      - (root): Additional property bootstrapMode is not allowed
      - (root): Additional property chartOperator is not allowed
      - (root): Additional property clusterCA is not allowed
      - (root): Additional property subscriptionID is not allowed
      - (root): Additional property ciliumNetworkPolicy is not allowed
      - (root): Additional property gcpProject is not allowed
      - (root): Additional property cluster is not allowed
      - (root): Additional property managementCluster is not allowed
      - global: Additional property podSecurityStandards is not allowed
